### PR TITLE
Combined Dependabot PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@nestjs/cli": "9.4.0",
-    "@nestjs/testing": "9.4.0",
+    "@nestjs/testing": "10.1.2",
     "@types/chai": "4.3.4",
     "@types/chai-as-promised": "7.1.5",
     "@types/mocha": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-prettier": "8.8.0",
     "eslint-plugin-prettier": "4.2.1",
     "mocha": "10.2.0",
-    "prettier": "2.8.7",
+    "prettier": "3.0.0",
     "proxyquire": "2.1.3",
     "sinon": "11.1.2",
     "ts-node": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/mocha": "10.0.1",
     "@types/node": "18.15.11",
     "@types/proxyquire": "1.3.28",
-    "@types/sinon": "10.0.13",
+    "@types/sinon": "10.0.15",
     "@typescript-eslint/eslint-plugin": "5.58.0",
     "@typescript-eslint/parser": "5.58.0",
     "c8": "7.13.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/proxyquire": "1.3.28",
     "@types/sinon": "10.0.13",
     "@typescript-eslint/eslint-plugin": "5.58.0",
-    "@typescript-eslint/parser": "5.58.0",
+    "@typescript-eslint/parser": "5.62.0",
     "c8": "7.13.0",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "proxyquire": "2.1.3",
     "sinon": "11.1.2",
     "ts-node": "10.9.1",
-    "typescript": "4.9.5"
+    "typescript": "5.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "c8": "7.13.0",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
-    "eslint": "8.38.0",
+    "eslint": "8.45.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-plugin-prettier": "4.2.1",
     "mocha": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@bips/core": "0.15.3",
-    "rimraf": "4.4.1",
+    "rimraf": "5.0.1",
     "web3": "1.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/chai": "4.3.4",
     "@types/chai-as-promised": "7.1.5",
     "@types/mocha": "10.0.1",
-    "@types/node": "18.15.11",
+    "@types/node": "20.4.5",
     "@types/proxyquire": "1.3.28",
     "@types/sinon": "10.0.13",
     "@typescript-eslint/eslint-plugin": "5.58.0",


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- #10 build(deps-dev): bump eslint from 8.38.0 to 8.45.0
- #9 build(deps-dev): bump @types/sinon from 10.0.13 to 10.0.15
- #8 build(deps): bump rimraf from 4.4.1 to 5.0.1
- #6 build(deps-dev): bump @typescript-eslint/parser from 5.58.0 to 5.62.0
- #5 build(deps-dev): bump @nestjs/testing from 9.4.0 to 10.1.2
- #3 build(deps-dev): bump @types/node from 18.15.11 to 20.4.5
- #2 build(deps-dev): bump typescript from 4.9.5 to 5.1.6
- #1 build(deps-dev): bump prettier from 2.8.7 to 3.0.0

⚠️ The following PRs were left out due to merge conflicts:
- #7 build(deps-dev): bump @typescript-eslint/eslint-plugin from 5.58.0 to 6.2.0

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action